### PR TITLE
Added skilldirectory_tester service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,16 @@ services:
     ports:
        - "8080:8080"
 
+  # SkillDirectory Tester
+  backend-tester:
+    image: maryville/skilldirectory-tester:master
+    container_name: skilldirectory_tester
+    environment:
+        API: "http://backend:8080"
+        SLACK_HOOK: "${SLACK_HOOK}"
+        SLACK_TOKEN: "${SLACK_TOKEN}"
 
+  # SkillDirectory UI
   web:
     image: maryville/skilldirectoryui:master
     restart: always


### PR DESCRIPTION
Addresses https://github.com/maryvilledev/skilldirectory/issues/187. Relies on https://github.com/maryvilledev/skilldirectory/pull/198/. This PR updates the docker-compose file to run the `skilldirectory-tester` image introduced in https://github.com/maryvilledev/skilldirectory/pull/198/. The `API` env var is constructed by the docker-compose file. However, the `SLACK_HOOK` and `SLACK_TOKEN` env vars are merely passed on from the host machine environment.